### PR TITLE
Add funds and margins API

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ end
 - Cancel an Order
 - Retrieve orders
 - Retrieve holdings
+- Retrieve funds and margins
 - Retrieve positions
 - Postback
 - Logout

--- a/lib/kite_connect_ex.ex
+++ b/lib/kite_connect_ex.ex
@@ -94,4 +94,14 @@ defmodule KiteConnectEx do
   """
   @spec instruments(String.t(), String.t()) :: {:ok, List.t()} | Response.error()
   defdelegate instruments(access_token, exchange), to: Instrument
+
+  @doc """
+  Get user's margins `funds_and_margins`
+
+  ## Example
+
+    {:ok, funds_and_margins} = KiteConnectEx.funds_and_margins("access-token", "equity")
+  """
+  @spec funds_and_margins(String.t(), String.t()) :: {:ok, List.t()} | Response.error()
+  defdelegate funds_and_margins(access_token, segment_type), to: User
 end

--- a/lib/kite_connect_ex/response.ex
+++ b/lib/kite_connect_ex/response.ex
@@ -7,7 +7,6 @@ defmodule KiteConnectEx.Response do
   @success_status "success"
   @error_status "error"
 
-
   @csv_content_type {"Content-Type", "text/csv"}
 
   @doc false

--- a/lib/kite_connect_ex/user/fund_and_margin.ex
+++ b/lib/kite_connect_ex/user/fund_and_margin.ex
@@ -1,0 +1,40 @@
+defmodule KiteConnectEx.User.FundAndMargin do
+  alias KiteConnectEx.User.FundAndMargin.AvailableSegment
+  alias KiteConnectEx.User.FundAndMargin.UtilisedSegment
+
+  @moduledoc """
+  Module to represent an fund and margin resource
+
+  - [Docs](https://kite.trade/docs/connect/v3/user/#funds-and-margins)
+  """
+
+  @keys [
+    enabled: false,
+    net: nil,
+    available: nil,
+    utilised: nil
+  ]
+
+  @type t :: %__MODULE__{
+          enabled: Bool.t(),
+          net: Float.t(),
+          available: %AvailableSegment{},
+          utilised: %UtilisedSegment{}
+        }
+
+  @derive {Jason.Encoder, only: Keyword.keys(@keys)}
+  defstruct @keys
+
+  def new(attributes) when is_map(attributes) do
+    struct(__MODULE__, %{
+      enabled: attributes["enabled"],
+      net: attributes["net"],
+      available: AvailableSegment.new(attributes["available"]),
+      utilised: UtilisedSegment.new(attributes["utilised"])
+    })
+  end
+
+  def new(_) do
+    struct(__MODULE__, %{})
+  end
+end

--- a/lib/kite_connect_ex/user/fund_and_margin/available_segment.ex
+++ b/lib/kite_connect_ex/user/fund_and_margin/available_segment.ex
@@ -1,0 +1,37 @@
+defmodule KiteConnectEx.User.FundAndMargin.AvailableSegment do
+  @moduledoc """
+  Module to represent an available segment resource
+
+  - [Docs](https://kite.trade/docs/connect/v3/user/#funds-and-margins)
+  """
+
+  @keys [
+    adhoc_margin: nil,
+    cash: nil,
+    collateral: nil,
+    intraday_payin: nil
+  ]
+
+  @type t :: %__MODULE__{
+          adhoc_margin: Float.t(),
+          cash: Float.t(),
+          collateral: Float.t(),
+          intraday_payin: Float.t()
+        }
+
+  @derive {Jason.Encoder, only: Keyword.keys(@keys)}
+  defstruct @keys
+
+  def new(attributes) when is_map(attributes) do
+    struct(__MODULE__, %{
+      adhoc_margin: attributes["adhoc_margin"],
+      cash: attributes["cash"],
+      collateral: attributes["collateral"],
+      intraday_payin: attributes["intraday_payin"]
+    })
+  end
+
+  def new(_) do
+    struct(__MODULE__, %{})
+  end
+end

--- a/lib/kite_connect_ex/user/fund_and_margin/utilised_segment.ex
+++ b/lib/kite_connect_ex/user/fund_and_margin/utilised_segment.ex
@@ -1,0 +1,52 @@
+defmodule KiteConnectEx.User.FundAndMargin.UtilisedSegment do
+  @moduledoc """
+  Module to represent an available segment resource
+
+  - [Docs](https://kite.trade/docs/connect/v3/user/#funds-and-margins)
+  """
+
+  @keys [
+    debits: nil,
+    exposure: nil,
+    m2m_realised: nil,
+    m2m_unrealised: nil,
+    option_premium: nil,
+    payout: nil,
+    span: nil,
+    holding_sales: nil,
+    turnover: nil
+  ]
+
+  @type t :: %__MODULE__{
+          debits: Float.t(),
+          exposure: Float.t(),
+          m2m_realised: Float.t(),
+          m2m_unrealised: Float.t(),
+          option_premium: Float.t(),
+          payout: Float.t(),
+          span: Float.t(),
+          holding_sales: Float.t(),
+          turnover: Float.t()
+        }
+
+  @derive {Jason.Encoder, only: Keyword.keys(@keys)}
+  defstruct @keys
+
+  def new(attributes) when is_map(attributes) do
+    struct(__MODULE__, %{
+      debits: attributes["debits"],
+      exposure: attributes["exposure"],
+      m2m_realised: attributes["m2m_realised"],
+      m2m_unrealised: attributes["m2m_unrealised"],
+      option_premium: attributes["option_premium"],
+      payout: attributes["payout"],
+      span: attributes["span"],
+      holding_sales: attributes["holding_sales"],
+      turnover: attributes["turnover"]
+    })
+  end
+
+  def new(_) do
+    struct(__MODULE__, %{})
+  end
+end


### PR DESCRIPTION
This will allow us to fetch equity funds and margins, in turn allowing us to fetch cash balance data.

```
curl "https://api.kite.trade/user/margins" \
    -H "X-Kite-Version: 3" \
    -H 'Authorization: token api_key:access_token'
```

**Sample Response**
```
{
  "status": "success",
  "data": {
    "equity": {
      "enabled": true,
      "net": 24966.7493,
      "available": {
        "adhoc_margin": 0,
        "cash": 25000,
        "collateral": 0,
        "intraday_payin": 0
      },
      "utilised": {
        "debits": 33.2507,
        "exposure": 0,
        "m2m_realised": -0.25,
        "m2m_unrealised": 0,
        "option_premium": 0,
        "payout": 0,
        "span": 0,
        "holding_sales": 0,
        "turnover": 0
      }
    },
    "commodity": {
      "enabled": true,
      "net": 25000,
      "available": {
        "adhoc_margin": 0,
        "cash": 25000,
        "collateral": 0,
        "intraday_payin": 0
      },
      "utilised": {
        "debits": 0,
        "exposure": 0,
        "m2m_realised": 0,
        "m2m_unrealised": 0,
        "option_premium": 0,
        "payout": 0,
        "span": 0,
        "holding_sales": 0,
        "turnover": 0
      }
    }
  }
}
```

### How to use
```
# to fetch data for equity segment
{:ok, funds_and_margins} = KiteConnectEx.funds_and_margins("access-token",  "equity")

# to fetch data for commodity segment
{:ok, funds_and_margins} = KiteConnectEx.funds_and_margins("access-token", "commodity")

# response
{:ok,
 %KiteConnectEx.User.FundAndMargin{
   available: %KiteConnectEx.User.FundAndMargin.AvailableSegment{
     adhoc_margin: 0,
     cash: 622.32,
     collateral: 0,
     intraday_payin: 0
   },
   enabled: true,
   net: 622.32,
   utilised: %KiteConnectEx.User.FundAndMargin.UtilisedSegment{
     debits: 0,
     exposure: 0,
     holding_sales: 0,
     m2m_realised: 0,
     m2m_unrealised: 0,
     option_premium: 0,
     payout: 0,
     span: 0,
     turnover: 0
   }
 }}
```

### References:
[Read more](https://kite.trade/docs/connect/v3/user/#funds-and-margins)